### PR TITLE
Fix shape mismatch on scenes other than garden

### DIFF
--- a/splatter.py
+++ b/splatter.py
@@ -490,7 +490,8 @@ class Splatter(nn.Module):
                     focal_y = self.current_camera.params[1] / self.render_downsample
                     print(focal_x)
                     print(focal_y)
-                    self.tile_info = Tiles(round(width), round(height), focal_x, focal_y, self.device)
+                    # breakpoint()
+                    self.tile_info = Tiles(int(self.ground_truth.shape[1]), int(self.ground_truth.shape[0]), focal_x, focal_y, self.device)
                     self.tile_info_cpp = self.tile_info.create_tiles()
 
         self.ray_info = RayInfo(

--- a/splatter.py
+++ b/splatter.py
@@ -267,7 +267,7 @@ class Tiles:
         top = int(self.padded_height - self.height)//2 
         left = int(self.padded_width - self.width)//2 
         #return image[top:top+int(self.height), left:left+int(self.width), :]
-        return image[top:top+int(self.height)-1, left:left+int(self.width), :]
+        return image[top:top+int(self.height), left:left+int(self.width), :]
     
     def create_tiles(self):
         self.tiles_left = torch.linspace(-self.padded_width/2, self.padded_width/2, self.n_tile_x + 1, device=self.device)[:-1]
@@ -490,7 +490,7 @@ class Splatter(nn.Module):
                     focal_y = self.current_camera.params[1] / self.render_downsample
                     print(focal_x)
                     print(focal_y)
-                    self.tile_info = Tiles(math.ceil(width), math.ceil(height), focal_x, focal_y, self.device)
+                    self.tile_info = Tiles(round(width), round(height), focal_x, focal_y, self.device)
                     self.tile_info_cpp = self.tile_info.create_tiles()
 
         self.ray_info = RayInfo(

--- a/splatter.py
+++ b/splatter.py
@@ -266,7 +266,6 @@ class Tiles:
         # output: height x width x 3
         top = int(self.padded_height - self.height)//2 
         left = int(self.padded_width - self.width)//2 
-        #return image[top:top+int(self.height), left:left+int(self.width), :]
         return image[top:top+int(self.height), left:left+int(self.width), :]
     
     def create_tiles(self):
@@ -490,7 +489,6 @@ class Splatter(nn.Module):
                     focal_y = self.current_camera.params[1] / self.render_downsample
                     print(focal_x)
                     print(focal_y)
-                    # breakpoint()
                     self.tile_info = Tiles(int(self.ground_truth.shape[1]), int(self.ground_truth.shape[0]), focal_x, focal_y, self.device)
                     self.tile_info_cpp = self.tile_info.create_tiles()
 


### PR DESCRIPTION
Fix for #1 
Used ground truth to set img size in Tiles instead of calculated width and height which is often off by one.
Tested on garden, bonsai, kitchen and stump scenes from mipnerf360 dataset.